### PR TITLE
Use new child_spec definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 elixir:
-  - '1.5.0'
-  - '1.6.0'
+  - 1.5
+  - 1.6
 otp_release:
   - 18.0
   - 18.3
@@ -9,6 +9,12 @@ otp_release:
   - 19.1
   - 20.0
   - 20.2
+matrix:
+  exclude:
+    - elixir: 1.6
+      otp_release: 18.0
+    - elixir: 1.6
+      otp_release: 18.3
 sudo: false
 before_script:
   - epmd -daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
-# TODO: Use language: :elixir when v1.4.0 is out.
-language: erlang
+language: elixir
+
+elixir:
+  - '1.5.0'
+  - '1.6.0'
 otp_release:
   - 18.0
   - 18.3
   - 19.0
   - 19.1
+  - 20.0
+  - 20.2
+
 sudo: false
+
 before_script:
-  - wget http://s3.hex.pm/builds/elixir/master.zip
-  - unzip -d elixir master.zip
-  - export PATH=$(pwd)/elixir/bin:${PATH}
   - epmd -daemon
   - mix deps.get --only test
+
 script:
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ elixir:
   - 1.6
 otp_release:
   - 18.0
-  - 18.3
   - 19.0
-  - 19.1
   - 20.0
-  - 20.2
 matrix:
   exclude:
     - elixir: 1.6
       otp_release: 18.0
-    - elixir: 1.6
-      otp_release: 18.3
 sudo: false
 before_script:
   - epmd -daemon

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: elixir
-
 elixir:
   - '1.5.0'
   - '1.6.0'
@@ -10,12 +9,10 @@ otp_release:
   - 19.1
   - 20.0
   - 20.2
-
 sudo: false
-
 before_script:
   - epmd -daemon
   - mix deps.get --only test
-
+  - MIX_ENV=test mix compile
 script:
   - mix test

--- a/lib/firenest/monitor.ex
+++ b/lib/firenest/monitor.ex
@@ -8,8 +8,6 @@ defmodule Firenest.Monitor do
   `Firenest.Topology.monitor/3` functionality.
   """
 
-  import Supervisor.Spec
-
   @doc """
   Starts the monitoring service on `topology` with name `monitor`.
 
@@ -21,8 +19,8 @@ defmodule Firenest.Monitor do
     supervisor = Module.concat(monitor, "Supervisor")
 
     children = [
-      worker(Firenest.Monitor.Local, [topology, local, remote]),
-      worker(Firenest.Monitor.Remote, [topology, local, remote]),
+      {Firenest.Monitor.Local, [topology, local, remote]},
+      {Firenest.Monitor.Remote, [topology, local, remote]},
     ]
 
     Supervisor.start_link(children, name: supervisor, strategy: :one_for_all)
@@ -42,7 +40,7 @@ defmodule Firenest.Monitor.Local do
 
   use GenServer
 
-  def start_link(topology, local, remote) do
+  def start_link([topology, local, remote]) do
     GenServer.start_link(__MODULE__, {topology, remote}, name: local)
   end
 
@@ -126,7 +124,7 @@ defmodule Firenest.Monitor.Remote do
 
   use GenServer
 
-  def start_link(topology, local, remote) do
+  def start_link([topology, local, remote]) do
     GenServer.start_link(__MODULE__, {topology, local}, name: remote)
   end
 

--- a/lib/firenest/pub_sub.ex
+++ b/lib/firenest/pub_sub.ex
@@ -54,7 +54,7 @@ defmodule Firenest.PubSub do
       end
     end
 
-    def start_link([name, pubsub, module, function]) do
+    def start_link({name, pubsub, module, function}) do
       GenServer.start_link(__MODULE__, {pubsub, module, function}, name: name)
     end
 
@@ -119,7 +119,7 @@ defmodule Firenest.PubSub do
 
     children = [
       {Registry, registry},
-      {Dispatcher, [dispatcher, pubsub, module, function]}
+      {Dispatcher, {dispatcher, pubsub, module, function}}
     ]
 
     Supervisor.start_link(children, strategy: :rest_for_one, name: supervisor)

--- a/lib/firenest/pub_sub.ex
+++ b/lib/firenest/pub_sub.ex
@@ -12,8 +12,8 @@ defmodule Firenest.PubSub do
   alongside the desired topology:
 
       children = [
-        supervisor(Firenest.Topology, [MyApp.Topology, adapter: Firenest.Topology.Erlang]),
-        supervisor(Firenest.PubSub, [MyApp.PubSub, topology: MyApp.Topology])
+        {Firenest.Topology, [MyApp.Topology, adapter: Firenest.Topology.Erlang]},
+        {Firenest.PubSub, [MyApp.PubSub, topology: MyApp.Topology]}
       ]
 
   Once the topology and pubsub processes are started, processes
@@ -54,7 +54,7 @@ defmodule Firenest.PubSub do
       end
     end
 
-    def start_link(name, pubsub, module, function) do
+    def start_link([name, pubsub, module, function]) do
       GenServer.start_link(__MODULE__, {pubsub, module, function}, name: name)
     end
 
@@ -108,13 +108,13 @@ defmodule Firenest.PubSub do
     supervisor = Module.concat(pubsub, "Supervisor")
     dispatcher = Module.concat(pubsub, "Dispatcher")
     registry = [meta: [pubsub: {topology, dispatcher, module, function}],
-                partitions: partitions]
-
-    import Supervisor.Spec
+                partitions: partitions,
+                keys: :duplicate,
+                name: pubsub]
 
     children = [
-      supervisor(Registry, [:duplicate, pubsub, registry]),
-      worker(Dispatcher, [dispatcher, pubsub, module, function])
+      {Registry, registry},
+      {Dispatcher, [dispatcher, pubsub, module, function]}
     ]
 
     Supervisor.start_link(children, strategy: :rest_for_one, name: supervisor)

--- a/lib/firenest/topology/erlang.ex
+++ b/lib/firenest/topology/erlang.ex
@@ -32,7 +32,8 @@ defmodule Firenest.Topology.Erlang do
 
     use Elixir.Supervisor
 
-    def start_link(topology, opts) do
+    def start_link(opts) do
+      topology = opts[:name]
       name = Module.concat(topology, "Supervisor")
       Elixir.Supervisor.start_link(__MODULE__, {topology, opts}, name: name)
     end
@@ -57,7 +58,7 @@ defmodule Firenest.Topology.Erlang do
   @behaviour Firenest.Topology
   @timeout 5000
 
-  defdelegate start_link(topology, opts), to: Supervisor
+  defdelegate start_link(opts), to: Supervisor
 
   def subscribe(topology, pid) when is_pid(pid) do
     GenServer.call(topology, {:subscribe, pid})

--- a/lib/firenest/topology/erlang.ex
+++ b/lib/firenest/topology/erlang.ex
@@ -42,10 +42,13 @@ defmodule Firenest.Topology.Erlang do
       true = :ets.insert(topology, [adapter: Firenest.Topology.Erlang])
 
       children = [
-        worker(GenServer, [Firenest.Topology.Erlang, topology, [name: topology]])
+        %{
+          id: topology,
+          start: {GenServer, :start_link, [Firenest.Topology.Erlang, topology, [name: topology]]}
+        }
       ]
 
-      supervise(children, strategy: :one_for_one)
+      Supervisor.init(children, strategy: :one_for_one)
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Firenest.Mixfile do
   def project do
     [app: :firenest,
      version: "0.1.0",
-     elixir: "~> 1.5.0",
+     elixir: "~> 1.5",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      elixirc_paths: elixirc_paths(Mix.env),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Firenest.Mixfile do
   def project do
     [app: :firenest,
      version: "0.1.0",
-     elixir: "~> 1.4-dev",
+     elixir: "~> 1.5.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      elixirc_paths: elixirc_paths(Mix.env),

--- a/test/firenest/pub_sub_test.exs
+++ b/test/firenest/pub_sub_test.exs
@@ -7,7 +7,7 @@ defmodule Firenest.PubSubTest do
   setup_all do
     nodes = [:"first@127.0.0.1", :"second@127.0.0.1"]
     pubsub = Firenest.Test.PubSub
-    Firenest.Test.start_link(nodes, P, [pubsub, [topology: Firenest.Test]])
+    Firenest.Test.start_link(nodes, P, [[name: pubsub, topology: Firenest.Test]])
     {:ok, topology: Firenest.Test, evaluator: Firenest.Test.Evaluator, pubsub: pubsub}
   end
 
@@ -184,15 +184,16 @@ defmodule Firenest.PubSubTest do
     end
   end
 
-  describe "start_link/2" do
+  describe "start_link/1" do
     test "supports and validates :partitions option", %{topology: topology} do
       Process.flag(:trap_exit, true)
-      {:error, _} = P.start_link(:pubsub_with_partitions, topology: topology, partitions: 0)
+      {:error, _} = P.start_link(name: :pubsub_with_partitions,
+                                 topology: topology, partitions: 0)
     end
 
     test "supports custom dispatching", %{topology: topology, topic: topic} do
-      P.start_link(:pubsub_with_dispatching, topology: topology,
-                                             dispatcher: {__MODULE__, :custom_dispatcher})
+      P.start_link(name: :pubsub_with_dispatching,
+                         topology: topology, dispatcher: {__MODULE__, :custom_dispatcher})
       P.subscribe(:pubsub_with_dispatching, topic, :register)
       P.broadcast_from(:pubsub_with_dispatching, self(), topic, :message)
       assert_received {:custom_dispatcher, :register, pid, :message} when pid == self()

--- a/test/shared/test.ex
+++ b/test/shared/test.ex
@@ -59,7 +59,7 @@ defmodule Firenest.Test do
   Starts firenest on the given nodes.
   """
   def start_firenest(nodes, options) do
-    start_link(nodes, Firenest.Topology, [[{:name, Firenest.Test} | options]])
+    start_link(nodes, Firenest.Topology, [[name: Firenest.Test] ++ options])
     start_link(nodes, Evaluator, [])
   end
 

--- a/test/shared/test.ex
+++ b/test/shared/test.ex
@@ -59,7 +59,7 @@ defmodule Firenest.Test do
   Starts firenest on the given nodes.
   """
   def start_firenest(nodes, options) do
-    start_link(nodes, Firenest.Topology, [Firenest.Test, options])
+    start_link(nodes, Firenest.Topology, [[{:name, Firenest.Test} | options]])
     start_link(nodes, Evaluator, [])
   end
 


### PR DESCRIPTION
This PR updates several modules to make use of the [new child_spec](https://elixir-lang.org/blog/2017/07/25/elixir-v1-5-0-released/) definitions.

`mix.exs` was also bumped for `1.4-dev` to `1.5.0` as a consequence.